### PR TITLE
Change the order for ranking rules

### DIFF
--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -49,10 +49,10 @@ class MeiliSearchHelper:
         'rankingRules': [
             'words',
             'typo',
-            'attribute',
             'proximity',
             'exactness',
             'page_rank:desc',
+            'attribute',
             'level:desc',
             'position:asc'
         ],
@@ -75,7 +75,8 @@ class MeiliSearchHelper:
             'objectID',
             'page_rank',
             'level',
-            'position'
+            'position',
+            'page_rank'
         ],
         'displayedAttributes': [
             'hierarchy_radio_lvl0',


### PR DESCRIPTION
The indexing in docs-scrape wasn't working quite well.
It was displaying a lot of content from the blog that was less important (lower page_rank) than the content from the main website (feature/products). 

The scraper has its own internal ranking, and the ranking of the `attribute` was higher than the page_rank. 

So, the `attribute` ranks if it found something in lvl1, lvl2, or content, and since we have more than 300 articles on the blog, it almost always finds something in lvl1 of the blog. 

However, we want to prioritize the main website (corpsite) more.

I've also added the page_rank to the `displayedAttributes` to allow for a manual sorting on the front-end