### PR TITLE
Improve supported settings

### DIFF
--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -178,10 +178,15 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
 
     def parse_from_start_url(self, old_response):
         if "jobscore.zendesk.com" in old_response.request.url:
-            article_data = json.loads(old_response.body)['article']
-            new_body_html = '<h1>' + article_data['title'] + '</h1>'
-            new_body_html += article_data['body']
+            response_body = json.loads(old_response.body)
+            article_data = response_body.get('article', {})
+
+            new_body_html = '<h1>' + article_data.get('title', '') + '</h1>'
+            new_body_html += article_data.get('body', '')
             new_body_html = '<article>' + new_body_html + '</article>'
+            new_body_html += '<section>' + json.dumps(response_body.get('sections', {})) + '</section>'
+            new_body_html += '<category>' + json.dumps(response_body.get('categories', {})) + '</category>'
+            new_body_html += '<tags>' + json.dumps(article_data.get('label_names', [])) + '</tags>'
 
             new_response = AttributeDict({
                 "encoding": "utf-8",

--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -72,6 +72,7 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
         self.name = config.index_uid
         self.allowed_domains = config.allowed_domains
         self.start_urls_full = config.start_urls
+        self.start_url_configs = dict([(start_url['url'], start_url)  for start_url in config.start_urls])
         self.start_urls = [start_url['url'] for start_url in config.start_urls]
         # We need to ensure that the stop urls are scheme agnostic too if it represents URL
         self.stop_urls = [DocumentationSpider.to_any_scheme(stop_url) for
@@ -140,7 +141,7 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
         # We crawl the start URL in order to ensure we didn't miss anything (Even if we used the sitemap)
         for url in self.start_urls:
             yield Request(url,
-                          callback=self.parse_from_start_url if self.scrape_start_urls else self.parse,
+                          callback=self.parse_from_start_url if self.start_url_configs[url].get('scrape_start_url', True) else self.parse,
                           # If we wan't to crawl (default behavior) without scraping, we still need to let the
                           # crawling spider acknowledge the content by parsing it with the built-in method
                           meta={

--- a/scraper/src/strategies/abstract_strategy.py
+++ b/scraper/src/strategies/abstract_strategy.py
@@ -84,7 +84,7 @@ class AbstractStrategy:
         if AbstractStrategy.will_skip_node(node, level, selectors):
             return
 
-        if node.text or node.tag == 'img':
+        if node.text or node.tag == 'img' or node.tag == 'meta':
             node_attrs_to_keep = AbstractStrategy.get_allowed_node_attrs(node, level, selectors)
 
             text = node.text if node.text is not None else ''

--- a/scraper/src/strategies/abstract_strategy.py
+++ b/scraper/src/strategies/abstract_strategy.py
@@ -159,7 +159,7 @@ class AbstractStrategy:
         if len(text) == 0:
             return None
 
-        return AbstractStrategy.escape(text, level, selectors)
+        return AbstractStrategy.escape(text)
 
     @staticmethod
     def remove_from_dom(dom, exclude_selectors):

--- a/scraper/src/strategies/abstract_strategy.py
+++ b/scraper/src/strategies/abstract_strategy.py
@@ -101,7 +101,8 @@ class AbstractStrategy:
                 yield e.tail
 
     @staticmethod
-    def escape(text, level=None, selectors=None):
+    def escape(text):
+        """We don't want to escape every html, and there is no selector-level config for that (sigh)"""
         # text = html.escape(text)
 
         for tag in AbstractStrategy.keep_tags:
@@ -134,7 +135,7 @@ class AbstractStrategy:
         if len(text) == 0:
             return None
 
-        return AbstractStrategy.escape(text, level, selectors)
+        return AbstractStrategy.escape(text)
 
     @staticmethod
     def get_text_from_nodes(elements, strip_chars=None, level=None, selectors=None):

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -116,7 +116,7 @@ class DefaultStrategy(AbstractStrategy):
 
             # We only save content for the 'text' matches
             content = None if current_level != 'content' else self.get_text(
-                node, self.get_strip_chars(current_level, selectors))
+                node, self.get_strip_chars(current_level, selectors), current_level, selectors)
 
             if (
                     content is None or content == "") and current_level == 'content':
@@ -215,7 +215,9 @@ class DefaultStrategy(AbstractStrategy):
                     matching_nodes,
                     self.get_strip_chars(attribute_name,
                                          selectors[current_level][
-                                             'attributes'])
+                                             'attributes']),
+                    current_level,
+                    selectors
                 )
             return attributes
 
@@ -223,7 +225,7 @@ class DefaultStrategy(AbstractStrategy):
             return self.global_content[current_level]
 
         return self.get_text(node,
-                             self.get_strip_chars(current_level, selectors))
+                             self.get_strip_chars(current_level, selectors), current_level, selectors)
 
     @staticmethod
     def _get_closest_anchor(anchors):
@@ -279,7 +281,9 @@ class DefaultStrategy(AbstractStrategy):
                 matching_dom_nodes = self.select(level_selector['selector'])
                 self.global_content[level] = self.get_text_from_nodes(
                     matching_dom_nodes,
-                    self.get_strip_chars(level, selectors))
+                    self.get_strip_chars(level, selectors),
+                    level,
+                    selectors)
 
                 if self.global_content[level] is None and level_selector[
                     'default_value'] is not None:


### PR DESCRIPTION
## Changes Done
- Scrapper html results are not longer "sanitized", as it changed content that should be kept whole (`<a>` => `&lt;a&gt;`)
- For security reasons, script tags are now skipped (Settings changed in `selectors_exclude`: [Improve search results content corpsite#599](https://github.com/jobscore/corpsite/pull/599/files#diff-8f19feb893b1270d4c888091b2728cf8f8714da5822f593288959436d802664cR280))
- New settings are now supported on meilisearch scrapper

### New settings on meilisearch scrapper
This scrapper provides several configs only at the global level, although most of them are useful on a selector-level basis. The following new configs are now available for selectors:

## Selector attribute: keep_tags
`keep_tags` will allow a tag and the allowed attributes into the indexed data. It is also possible to provide an empty attributes list to allow just the tag without any additional attribute. Examples:

### Retrieve blog tags (each tag is inside its own `<a/>`)
Results will have the following format: `<a>Tag 1</a> <a>Tag 2</a>`
```json
"lvl5": {
  "selector": ".post-tags--single a",
  "global": true,
  "default_value": "",
  "keep_tags": {
    "a": []
  }
}
```

### Retrieve blog post author's avatar
Results will have the following format: `<img src="author_avatar"></img>`
```json
"lvl4": {
  "selector": ".blog__box__editor__picture",
  "global": true,
  "default_value": "",
  "keep_tags": {
    "img": ["src"]
  }
}
```

## Selector attribute: classname_exclude 
`classname_exclude` will allow one to ignore certain content from a parent selector. For instance, it is used to ignore the social buttons inside a blog post content area. 

### Note: Due to several meilisearch scrapper limitations, a simple substring check is done on each DOM node "class" attribute. This is *not* a css selector

Example: Inside a corpsite blog post body, ignore content on its footer, such as comment button or social buttons
```json
"text": {
  "selector": ".blog__box__content",
  "classname_exclude": ["post-tags--single", "blog__show-comments", "disqus_thread", "blog__bottom__share"]
}
```

## Start_url attribute: scrape_start_url
`scrape_start_url` originally is a global attribute. Since we may want to skip some starting pages, like the blog, this setting can now be defined for each starting url, individually.
```json
{
  "url": "https://www.jobscore.com/blog/",
  "selectors_key": "blog",
  "scrape_start_url": false
}
```

## Scrapped data screenshot
![image](https://github.com/jobscore/docs-scraper/assets/7245754/f1073b29-f50e-464d-aa76-aec96429879c)
