### PR TITLE
Allow to conditionally apply js_render for certain pages

### DIFF
--- a/scraper/src/custom_downloader_middleware.py
+++ b/scraper/src/custom_downloader_middleware.py
@@ -16,7 +16,14 @@ class CustomDownloaderMiddleware:
         self.driver = CustomDownloaderMiddleware.driver
 
     def process_request(self, request, spider):
-        if not spider.js_render:
+        skip_js_render = False
+
+        for start_url in spider.start_urls_full:
+            if start_url['compiled_url'].match(request.url):
+                skip_js_render = start_url.get('skip_js_render', False)
+                break
+
+        if not spider.js_render or skip_js_render:
             return None
 
         if spider.remove_get_params:


### PR DESCRIPTION
This feature allows to control which pages are loaded using Chromedriver. It is a full-fledged browser, which allows to run javascript before indexing the page content.

For now, we only want to execute javascript on pricing page, as shown on the following screenshots.

## Screenshots

### Before
![image](https://github.com/jobscore/docs-scraper/assets/7245754/b4e9f1c0-ed1a-4d8c-85b1-fdb0464c6fa3)

### After
![image](https://github.com/jobscore/docs-scraper/assets/7245754/8bb8c59d-4e77-4fa6-9335-bfb4dd4e87dc)

## Configuration example
```js
{
  "index_uid": "corpsite-fresh",
  "start_urls": [
    {
      "url": "https://www.jobscore.com/pricing/",
      "selectors_key": "website_pricing",
      "page_rank": 10,
      "scrape_start_url": true,
      "ignore_query_params": true,
      "js_render": true // Let this page use chromedriver
    },
    {
      "url": "https://www.jobscore.com/blog/hiring-prcess-guide/",
      "selectors_key": "blog",
      "page_rank": 5,
      "scrape_start_url": true,
      "ignore_query_params": false,
      "js_render": false // Skip chromedriver for this page (javascript not needed)
    }
  ],
  "js_render": true // Enable js_render globally
}
```