### PR TITLE
Support 'regex' field for start url matching

### DIFF
--- a/scraper/src/config/urls_parser.py
+++ b/scraper/src/config/urls_parser.py
@@ -14,7 +14,7 @@ class UrlsParser:
             if isinstance(start_url, str):
                 start_url = {'url': start_url}
 
-            start_url['compiled_url'] = re.compile(start_url['url'])
+            start_url['compiled_url'] = re.compile(start_url.get('regex', start_url['url']))
 
             if "scrape" not in start_url:
                 start_url['scrape'] = True
@@ -28,7 +28,7 @@ class UrlsParser:
             if "selectors_key" not in start_url:
                 start_url['selectors_key'] = 'default'
 
-            matches = UrlsParser.get_url_variables_name(start_url['url'])
+            matches = UrlsParser.get_url_variables_name(start_url.get('regex', start_url['url']))
 
             start_url['url_attributes'] = {}
             for match in matches:


### PR DESCRIPTION
We have an issue with list pages `/resources/` being included in the same category as their children (`/resources/foo`). This new scraper feature should allow for a `regex` property, which filters for regex that may match.

Usage example:
```
{
  "url": "https://www.jobscore.com/resources/",
  "regex": "www.jobscore.com\/resources\/[a-zA-Z0-9]+.+",
  "selectors_key": "website_resources",
  "page_rank": 8,
  "scrape_start_url": false,
  "ignore_query_params": true,
}
```

`/resources/?foo=bar` won't match the above expression, while `/resources/foo` does